### PR TITLE
Add YARD documentation across public APIs

### DIFF
--- a/lib/blue_factory.rb
+++ b/lib/blue_factory.rb
@@ -2,6 +2,10 @@ require_relative 'blue_factory/configuration'
 require_relative 'blue_factory/server'
 require_relative 'blue_factory/version'
 
+##
+# Root namespace for the BlueFactory feed generator library.
 module BlueFactory
+  ##
+  # AT Protocol feed generator record type.
   FEED_GENERATOR_TYPE = 'app.bsky.feed.generator'
 end

--- a/lib/blue_factory/configuration.rb
+++ b/lib/blue_factory/configuration.rb
@@ -7,16 +7,32 @@ module BlueFactory
   extend Feeds
   extend Interactions
 
+  ##
+  # Builds the service DID based on the configured hostname.
+  #
+  # @return [String] DID of the service.
   def self.service_did
     'did:web:' + hostname
   end
 
+  ##
+  # Current application environment.
+  #
+  # @return [Symbol] the environment derived from APP_ENV or RACK_ENV.
   def self.environment
     (ENV['APP_ENV'] || ENV['RACK_ENV'] || :development).to_sym
   end
 
+  ##
+  # Defines configurable settings for the service.
   configurable :publisher_did, :hostname, :validate_responses, :enable_unsafe_auth
 
+  ##
+  # Sets a configuration value, with warnings for deprecated options.
+  #
+  # @param property [String, Symbol] configuration key
+  # @param value [Object] value to assign
+  # @return [void]
   def self.set(property, value)
     if property.to_sym == :enable_unsafe_auth
       puts "==="

--- a/lib/blue_factory/errors.rb
+++ b/lib/blue_factory/errors.rb
@@ -1,31 +1,51 @@
+##
+# Namespace for error types raised by BlueFactory.
 module BlueFactory
+  ##
+  # Raised when authentication is missing or invalid.
   class AuthorizationError < StandardError
+    # @return [String, nil] the error type identifier for response payloads
     attr_reader :error_type
 
+    # @param message [String] human-friendly error description
+    # @param error_type [String, nil] optional error code for the client
     def initialize(message = "Authentication required", error_type = nil)
       super(message)
       @error_type = error_type
     end
   end
 
+  ##
+  # Raised when feed keys fail validation.
   class InvalidKeyError < StandardError
   end
 
+  ##
+  # Raised when a request is malformed or missing required parameters.
   class InvalidRequestError < StandardError
+    # @return [String, nil] the error type identifier for response payloads
     attr_reader :error_type
 
+    # @param message [String] human-friendly error description
+    # @param error_type [String, nil] optional error code for the client
     def initialize(message, error_type = nil)
       super(message)
       @error_type = error_type
     end
   end
 
+  ##
+  # Raised when a feed response does not match the expected shape.
   class InvalidResponseError < StandardError
   end
 
+  ##
+  # Raised when a feed class exposes an unexpected API.
   class InvalidFeedClassError < StandardError
   end
 
+  ##
+  # Raised when a feed URI references an unsupported algorithm.
   class UnsupportedAlgorithmError < StandardError
   end
 end

--- a/lib/blue_factory/interaction.rb
+++ b/lib/blue_factory/interaction.rb
@@ -1,5 +1,9 @@
 module BlueFactory
+  ##
+  # Represents a single feed interaction event.
   class Interaction
+    ##
+    # Mapping of event identifiers to internal symbols.
     EVENTS = {
       'app.bsky.feed.defs#interactionLike' => :like,
       'app.bsky.feed.defs#interactionQuote' => :quote,
@@ -10,8 +14,19 @@ module BlueFactory
       'app.bsky.feed.defs#requestMore' => :request_more
     }
 
-    attr_reader :item, :event, :context, :req_id, :type
+    # @return [String] the URI of the feed item
+    attr_reader :item
+    # @return [String] the raw interaction event identifier
+    attr_reader :event
+    # @return [String, nil] optional feed context
+    attr_reader :context
+    # @return [String, nil] optional request identifier
+    attr_reader :req_id
+    # @return [Symbol, nil] normalized event type
+    attr_reader :type
 
+    ##
+    # @param data [Hash] interaction payload from the API
     def initialize(data)
       @item = data['item']
       @event = data['event']

--- a/lib/blue_factory/modules/configurable.rb
+++ b/lib/blue_factory/modules/configurable.rb
@@ -1,5 +1,12 @@
 module BlueFactory
+  ##
+  # Adds configuration helpers to the extending class or module.
   module Configurable
+    ##
+    # Initializes configurable properties when the module is extended.
+    #
+    # @param target [Module] the extending module or class
+    # @return [void]
     def self.extended(target)
       target.instance_variable_set('@properties', [])
     end
@@ -10,6 +17,13 @@ module BlueFactory
       singleton_class.attr_reader(*properties)
     end
 
+    ##
+    # Sets a configurable property on the receiving module.
+    #
+    # @param property [String, Symbol] configuration key
+    # @param value [Object] value to assign
+    # @return [void]
+    # @raise [NoMethodError] if the property is not defined
     def set(property, value)
       if @properties.include?(property.to_sym)
         self.instance_variable_set("@#{property}", value)

--- a/lib/blue_factory/modules/feeds.rb
+++ b/lib/blue_factory/modules/feeds.rb
@@ -1,22 +1,49 @@
 module BlueFactory
+  ##
+  # Maintains a registry of feed classes by key.
   module Feeds
+    ##
+    # Initializes the feeds registry when the module is extended.
+    #
+    # @param target [Module] the extending module or class
+    # @return [void]
     def self.extended(target)
       target.instance_variable_set('@feeds', {})
     end
 
+    ##
+    # Registers a feed class with a key.
+    #
+    # @param key [String] feed key
+    # @param feed_class [Class] feed implementation
+    # @return [void]
+    # @raise [InvalidKeyError] if the key is invalid
     def add_feed(key, feed_class)
       validate_key(key)
       @feeds[key.to_s] = feed_class
     end
 
+    ##
+    # Lists all configured feed keys.
+    #
+    # @return [Array<String>] available feed keys
     def feed_keys
       @feeds.keys
     end
 
+    ##
+    # Retrieves a feed class by key.
+    #
+    # @param key [String] feed key
+    # @return [Class, nil] feed class if registered
     def get_feed(key)
       @feeds[key.to_s]
     end
 
+    ##
+    # Returns all registered feed classes.
+    #
+    # @return [Array<Class>] feed implementations
     def all_feeds
       @feeds.values
     end

--- a/lib/blue_factory/modules/interactions.rb
+++ b/lib/blue_factory/modules/interactions.rb
@@ -1,9 +1,18 @@
 module BlueFactory
+  ##
+  # Adds interaction callback support to the host class/module.
   module Interactions
+    ##
+    # Registers a callback for incoming interactions.
+    #
+    # @yieldparam interactions [Array<Interaction>] incoming interactions
+    # @yieldparam context [RequestContext] request context for the interaction
+    # @return [void]
     def on_interactions(&block)
       @interactions_handler = block
     end
 
+    # @return [Proc, nil] the current interaction handler
     attr_accessor :interactions_handler
   end
 end

--- a/lib/blue_factory/output_generator.rb
+++ b/lib/blue_factory/output_generator.rb
@@ -1,9 +1,19 @@
 require_relative 'errors'
 
 module BlueFactory
+  ##
+  # Builds the feed skeleton response structure expected by AT Protocol.
   class OutputGenerator
+    ##
+    # Regular expression for validating post URIs.
     AT_URI_REGEXP = %r(^at://did:(plc:[a-z0-9]+|web:[a-z0-9\-]+(\.[a-z0-9\-]+)+)/app\.bsky\.feed\.post/[a-z0-9]+$)
 
+    ##
+    # Generates the serialized feed response payload.
+    #
+    # @param response [Hash] feed response data from the feed class
+    # @return [Hash] validated response in the AT Protocol format
+    # @raise [InvalidResponseError] when the response is missing required keys
     def generate(response)
       output = {}
 
@@ -23,6 +33,12 @@ module BlueFactory
       output
     end
 
+    ##
+    # Normalizes a feed entry as either a post string or a hash.
+    #
+    # @param object [String, Hash] feed entry payload
+    # @return [Hash] normalized post entry
+    # @raise [InvalidResponseError] if the entry type is invalid
     def process_post_element(object)
       if object.is_a?(String)
         validate_uri(object)
@@ -34,6 +50,12 @@ module BlueFactory
       end
     end
 
+    ##
+    # Converts a post hash to the expected skeleton shape.
+    #
+    # @param object [Hash] hash including :post and optional metadata
+    # @return [Hash] normalized post hash
+    # @raise [InvalidResponseError] if the post hash is missing required keys
     def process_post_hash(object)
       post = {}
 
@@ -55,6 +77,12 @@ module BlueFactory
       post
     end
 
+    ##
+    # Builds the reason payload for a post entry.
+    #
+    # @param reason [Hash] reason metadata
+    # @return [Hash] skeleton reason payload
+    # @raise [InvalidResponseError] if the reason data is invalid
     def process_post_reason(reason)
       raise InvalidResponseError, "Invalid post reason: #{reason.inspect}" unless reason.is_a?(Hash)
 
@@ -72,6 +100,12 @@ module BlueFactory
       end
     end
 
+    ##
+    # Validates that a URI is in the expected AT Protocol format.
+    #
+    # @param uri [String] post URI
+    # @return [void]
+    # @raise [InvalidResponseError] if the URI is invalid
     def validate_uri(uri)
       if !uri.is_a?(String)
         raise InvalidResponseError, "Post URI should be a string: #{uri.inspect}"

--- a/lib/blue_factory/request_context.rb
+++ b/lib/blue_factory/request_context.rb
@@ -1,21 +1,38 @@
 require_relative 'user_info'
 
 module BlueFactory
+  ##
+  # Wraps a Sinatra request with convenience helpers.
   class RequestContext
+    # @return [Sinatra::Request] underlying request object
     attr_accessor :request
 
+    ##
+    # @param request [Sinatra::Request] incoming HTTP request
     def initialize(request)
       @request = request
     end
 
+    ##
+    # Request environment hash.
+    #
+    # @return [Hash] Rack environment
     def env
       @request.env
     end
 
+    ##
+    # Parsed user information derived from authorization headers.
+    #
+    # @return [UserInfo] user info wrapper
     def user
       UserInfo.new(env['HTTP_AUTHORIZATION'])
     end
 
+    ##
+    # Indicates whether an authorization header was provided.
+    #
+    # @return [Boolean] true when authorization exists
     def has_auth?
       env['HTTP_AUTHORIZATION'] != nil
     end

--- a/lib/blue_factory/server.rb
+++ b/lib/blue_factory/server.rb
@@ -8,6 +8,8 @@ require_relative 'output_generator'
 require_relative 'request_context'
 
 module BlueFactory
+  ##
+  # Sinatra server exposing the feed generator endpoints.
   class Server < Sinatra::Base
     configure do
       disable :static
@@ -17,14 +19,28 @@ module BlueFactory
     end
 
     helpers do
+      ##
+      # Accessor for global configuration.
+      #
+      # @return [Module] BlueFactory configuration module
       def config
         BlueFactory
       end
 
+      ##
+      # Builds an AT Protocol feed URI from a key.
+      #
+      # @param key [String] feed key
+      # @return [String] feed URI
       def feed_uri(key)
         'at://' + config.publisher_did + '/' + FEED_GENERATOR_TYPE + '/' + key
       end
 
+      ##
+      # Serializes a JSON response payload.
+      #
+      # @param data [Hash] response payload
+      # @return [String] JSON string
       def json_response(data)
         content_type :json
         JSON.generate(data)
@@ -32,11 +48,25 @@ module BlueFactory
 
       alias json json_response
 
+      ##
+      # Builds a JSON error response.
+      #
+      # @param name [String] error name
+      # @param message [String] error message
+      # @param status [Integer] HTTP status code
+      # @return [Array<(Integer, String)>] status and JSON body
       def json_error(name, message, status: 400)
         content_type :json
         [status, JSON.generate({ error: name, message: message })]
       end
 
+      ##
+      # Validates and resolves a feed class from an AT URI.
+      #
+      # @param feed_uri [String] AT URI for the feed
+      # @return [Class] feed implementation
+      # @raise [InvalidRequestError] if the URI is invalid
+      # @raise [UnsupportedAlgorithmError] if the feed is not registered
       def get_feed(feed_uri)
         if feed_uri.to_s.empty?
           raise InvalidRequestError, "Error: Params must have the property \"feed\""

--- a/lib/blue_factory/tasks/support.rb
+++ b/lib/blue_factory/tasks/support.rb
@@ -3,9 +3,22 @@ require 'net/http'
 require 'uri'
 
 module BlueFactory
+  ##
+  # Convenience HTTP helpers for rake tasks.
   module Net
+    ##
+    # Raised when an HTTP response status is non-success.
     class ResponseError < StandardError; end
 
+    ##
+    # Executes a GET request against a feed generator endpoint.
+    #
+    # @param server [String] base server URL
+    # @param method [String, nil] optional XRPC method name
+    # @param params [Hash, nil] optional query parameters
+    # @param auth [String, nil] bearer token
+    # @return [Hash] parsed JSON response
+    # @raise [ResponseError] if the response status is not 2xx
     def self.get_request(server, method = nil, params = nil, auth: nil)
       headers = {}
       headers['Authorization'] = "Bearer #{auth}" if auth
@@ -22,6 +35,16 @@ module BlueFactory
       JSON.parse(response.body)
     end
 
+    ##
+    # Executes a POST request against a feed generator endpoint.
+    #
+    # @param server [String] base server URL
+    # @param method [String] XRPC method name
+    # @param data [Hash, String] request body
+    # @param auth [String, nil] bearer token
+    # @param content_type [String] HTTP content type
+    # @return [Hash] parsed JSON response
+    # @raise [ResponseError] if the response status is not 2xx
     def self.post_request(server, method, data, auth: nil, content_type: "application/json")
       headers = {}
       headers['Content-Type'] = content_type

--- a/lib/blue_factory/user_info.rb
+++ b/lib/blue_factory/user_info.rb
@@ -4,11 +4,20 @@ require 'json'
 require_relative 'errors'
 
 module BlueFactory
+  ##
+  # Parses authorization header information for a user.
   class UserInfo
+    ##
+    # @param auth_header [String, nil] authorization header value
     def initialize(auth_header)
       @auth = auth_header
     end
 
+    ##
+    # Extracts the bearer token from the authorization header.
+    #
+    # @return [String, nil] bearer token
+    # @raise [AuthorizationError] if the auth method is unsupported
     def token
       @token ||= begin
         if @auth.nil? || @auth.strip.empty?
@@ -21,6 +30,11 @@ module BlueFactory
       end
     end
 
+    ##
+    # Decodes the raw DID from the JWT payload.
+    #
+    # @return [String, nil] DID issuer value
+    # @raise [AuthorizationError] when the token format is invalid
     def raw_did
       return nil if token.nil?
 

--- a/lib/blue_factory/version.rb
+++ b/lib/blue_factory/version.rb
@@ -1,3 +1,5 @@
 module BlueFactory
+  ##
+  # Current gem version.
   VERSION = "0.2.1"
 end


### PR DESCRIPTION
### Motivation
- Provide YARD-style documentation for all public classes, modules, methods, and constants to improve discoverability and generated API docs.
- Clarify expected inputs/outputs and error conditions for core behaviors such as feed generation, request parsing, and HTTP task helpers.

### Description
- Add YARD comments and annotations for the root namespace and constant `FEED_GENERATOR_TYPE` in `lib/blue_factory.rb` and `lib/blue_factory/version.rb`.
- Document error classes in `lib/blue_factory/errors.rb` including `AuthorizationError`, `InvalidRequestError`, `InvalidResponseError`, `InvalidKeyError`, `InvalidFeedClassError`, and `UnsupportedAlgorithmError` with parameter/return info where appropriate.
- Add documentation for configuration and helpers in `lib/blue_factory/configuration.rb`, `lib/blue_factory/modules/configurable.rb`, `lib/blue_factory/modules/feeds.rb`, and `lib/blue_factory/modules/interactions.rb` including `configurable`, `add_feed`, `get_feed`, and `on_interactions` behaviors.
- Document runtime behavior and helpers in `lib/blue_factory/server.rb`, `lib/blue_factory/output_generator.rb`, `lib/blue_factory/request_context.rb`, `lib/blue_factory/user_info.rb`, `lib/blue_factory/interaction.rb`, and task HTTP helpers in `lib/blue_factory/tasks/support.rb` (YARD tags for parameters, return values, and raised errors); no functional code changes were made.

### Testing
- No automated tests were run for this change because it is documentation-only; there are no behavior changes to verify in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69700c017a688331aae226c1b7bf71e1)