### PR TITLE
Add comprehensive rack-test coverage for BlueFactory::Server

### DIFF
--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -19,7 +19,7 @@ describe BlueFactory::Server do
   end
 
   describe 'configuration verification' do
-    it 'raises ConfigurationError when hostname is nil' do
+    it 'should raise ConfigurationError when hostname is nil' do
       BlueFactory.set :hostname, nil
       BlueFactory::Server.class_variable_set(:@@config_checked, false)
 
@@ -27,7 +27,7 @@ describe BlueFactory::Server do
         .to raise_error(BlueFactory::ConfigurationError, /hostname/)
     end
 
-    it 'raises ConfigurationError when publisher_did is nil' do
+    it 'should raise ConfigurationError when publisher_did is nil' do
       BlueFactory.set :publisher_did, nil
       BlueFactory::Server.class_variable_set(:@@config_checked, false)
 
@@ -41,7 +41,7 @@ describe BlueFactory::Server do
     let(:feed_uri) { "at://#{publisher_did}/#{BlueFactory::FEED_GENERATOR_TYPE}/#{feed_key}" }
     let(:valid_post_uri) { 'at://did:plc:abc123def456/app.bsky.feed.post/abc123' }
 
-    it 'returns a valid skeleton response for a one-argument get_posts' do
+    it 'should return a valid skeleton response for a one-argument get_posts' do
       handler = mock('one_arg_handler')
       handler.expects(:call).with do |args|
         args[:feed] == feed_uri &&
@@ -63,16 +63,16 @@ describe BlueFactory::Server do
 
       get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: feed_uri, cursor: 'next', limit: 999
 
-      expect(last_response.status).to eq(200)
-      expect(last_response.headers['Content-Type']).to include('application/json')
-      expect(json_body).to eq(
+      last_response.status.should == 200
+      last_response.headers['Content-Type'].should include('application/json')
+      json_body.should == {
         'feed' => [{ 'post' => valid_post_uri }],
         'cursor' => 'cursor_token',
         'reqId' => 'req_token'
-      )
+      }
     end
 
-    it 'passes a RequestContext to a two-argument get_posts' do
+    it 'should pass a RequestContext to a two-argument get_posts' do
       handler = mock('two_arg_handler')
       handler.expects(:call).with do |args, context|
         args[:feed] == feed_uri && context.is_a?(BlueFactory::RequestContext)
@@ -92,11 +92,11 @@ describe BlueFactory::Server do
 
       get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: feed_uri
 
-      expect(last_response.status).to eq(200)
-      expect(json_body['feed']).to eq([{ 'post' => valid_post_uri }])
+      last_response.status.should == 200
+      json_body['feed'].should == [{ 'post' => valid_post_uri }]
     end
 
-    it 'raises InvalidFeedClassError when get_posts arity is unsupported' do
+    it 'should raise InvalidFeedClassError when get_posts arity is unsupported' do
       feed = Class.new do
         def get_posts; end
       end.new
@@ -107,37 +107,37 @@ describe BlueFactory::Server do
         .to raise_error(BlueFactory::InvalidFeedClassError, /arity 0/)
     end
 
-    it 'returns InvalidRequest when feed is missing' do
+    it 'should return InvalidRequest when feed is missing' do
       get '/xrpc/app.bsky.feed.getFeedSkeleton'
 
-      expect(last_response.status).to eq(400)
-      expect(json_body).to include(
+      last_response.status.should == 400
+      json_body.should include(
         'error' => 'InvalidRequest',
         'message' => 'Error: Params must have the property "feed"'
       )
     end
 
-    it 'returns InvalidRequest when feed is not a valid at-uri' do
+    it 'should return InvalidRequest when feed is not a valid at-uri' do
       get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: 'not-an-at-uri'
 
-      expect(last_response.status).to eq(400)
-      expect(json_body).to include(
+      last_response.status.should == 400
+      json_body.should include(
         'error' => 'InvalidRequest',
         'message' => 'Error: feed must be a valid at-uri'
       )
     end
 
-    it 'returns UnsupportedAlgorithm when the feed is not registered' do
+    it 'should return UnsupportedAlgorithm when the feed is not registered' do
       get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: feed_uri
 
-      expect(last_response.status).to eq(400)
-      expect(json_body).to include(
+      last_response.status.should == 400
+      json_body.should include(
         'error' => 'UnsupportedAlgorithm',
         'message' => 'Unsupported algorithm'
       )
     end
 
-    it 'returns UnsupportedAlgorithm when the URI does not match the registered feed' do
+    it 'should return UnsupportedAlgorithm when the URI does not match the registered feed' do
       feed = Class.new do
         def get_posts(args); end
       end.new
@@ -147,14 +147,14 @@ describe BlueFactory::Server do
       mismatched_uri = "at://did:plc:someoneelse/#{BlueFactory::FEED_GENERATOR_TYPE}/#{feed_key}"
       get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: mismatched_uri
 
-      expect(last_response.status).to eq(400)
-      expect(json_body).to include(
+      last_response.status.should == 400
+      json_body.should include(
         'error' => 'UnsupportedAlgorithm',
         'message' => 'Unsupported algorithm'
       )
     end
 
-    it 'returns Unauthorized when the feed raises AuthorizationError' do
+    it 'should return Unauthorized when the feed raises AuthorizationError' do
       feed = Class.new do
         def get_posts(_args, context)
           context.user.raw_did
@@ -167,14 +167,14 @@ describe BlueFactory::Server do
       header 'Authorization', 'Basic not-a-bearer-token'
       get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: feed_uri
 
-      expect(last_response.status).to eq(401)
-      expect(json_body).to include(
+      last_response.status.should == 401
+      json_body.should include(
         'error' => 'AuthenticationRequired',
         'message' => 'Unsupported authorization method'
       )
     end
 
-    it 'returns a generic InvalidResponse error in non-development environments' do
+    it 'should return a generic InvalidResponse error in non-development environments' do
       handler = mock('invalid_response_handler')
       handler.stubs(:call).returns({ posts: 'not-an-array' })
 
@@ -191,8 +191,8 @@ describe BlueFactory::Server do
 
       get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: feed_uri
 
-      expect(last_response.status).to eq(500)
-      expect(json_body).to include(
+      last_response.status.should == 500
+      json_body.should include(
         'error' => 'InvalidResponse',
         'message' => 'Feed response was invalid'
       )
@@ -200,7 +200,7 @@ describe BlueFactory::Server do
   end
 
   describe 'GET /xrpc/app.bsky.feed.describeFeedGenerator' do
-    it 'returns the service did and configured feed uris' do
+    it 'should return the service did and configured feed uris' do
       feed = Class.new do
         def get_posts(args); end
       end.new
@@ -210,24 +210,24 @@ describe BlueFactory::Server do
 
       get '/xrpc/app.bsky.feed.describeFeedGenerator'
 
-      expect(last_response.status).to eq(200)
-      expect(json_body).to eq(
+      last_response.status.should == 200
+      json_body.should == {
         'did' => "did:web:#{hostname}",
         'feeds' => [
           { 'uri' => "at://#{publisher_did}/#{BlueFactory::FEED_GENERATOR_TYPE}/alpha" },
           { 'uri' => "at://#{publisher_did}/#{BlueFactory::FEED_GENERATOR_TYPE}/beta" }
         ]
-      )
+      }
     end
   end
 
   describe 'GET /.well-known/did.json' do
-    it 'returns the expected DID document' do
+    it 'should return the expected DID document' do
       get '/.well-known/did.json'
 
-      expect(last_response.status).to eq(200)
-      expect(last_response.headers['Content-Type']).to include('application/json')
-      expect(json_body).to eq(
+      last_response.status.should == 200
+      last_response.headers['Content-Type'].should include('application/json')
+      json_body.should == {
         '@context' => ['https://www.w3.org/ns/did/v1'],
         'id' => "did:web:#{hostname}",
         'service' => [
@@ -237,7 +237,7 @@ describe BlueFactory::Server do
             'serviceEndpoint' => "https://#{hostname}"
           }
         ]
-      )
+      }
     end
   end
 
@@ -245,7 +245,7 @@ describe BlueFactory::Server do
     let(:interaction_event) { 'app.bsky.feed.defs#interactionSeen' }
     let(:interaction_item) { 'at://did:plc:abc123def456/app.bsky.feed.post/abc123' }
 
-    it 'calls the configured interactions handler' do
+    it 'should call the configured interactions handler' do
       received_interactions = nil
       received_context = nil
 
@@ -267,19 +267,19 @@ describe BlueFactory::Server do
 
       post '/xrpc/app.bsky.feed.sendInteractions', JSON.generate(payload), 'CONTENT_TYPE' => 'application/json'
 
-      expect(last_response.status).to eq(200)
-      expect(received_context).to be_a(BlueFactory::RequestContext)
-      expect(received_interactions.map(&:type)).to eq([:seen])
-      expect(received_interactions.map(&:item)).to eq([interaction_item])
-      expect(received_interactions.map(&:context)).to eq(['ctx'])
-      expect(received_interactions.map(&:req_id)).to eq(['req-1'])
+      last_response.status.should == 200
+      received_context.should be_a(BlueFactory::RequestContext)
+      received_interactions.map(&:type).should == [:seen]
+      received_interactions.map(&:item).should == [interaction_item]
+      received_interactions.map(&:context).should == ['ctx']
+      received_interactions.map(&:req_id).should == ['req-1']
     end
 
-    it 'returns MethodNotImplemented when no handler is configured' do
+    it 'should return MethodNotImplemented when no handler is configured' do
       post '/xrpc/app.bsky.feed.sendInteractions', JSON.generate(interactions: []), 'CONTENT_TYPE' => 'application/json'
 
-      expect(last_response.status).to eq(501)
-      expect(json_body).to include(
+      last_response.status.should == 501
+      json_body.should include(
         'error' => 'MethodNotImplemented',
         'message' => 'Method Not Implemented'
       )

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,15 +1,288 @@
 require 'spec_helper'
+require 'json'
 
 describe BlueFactory::Server do
+  let(:hostname) { 'feeds.example.com' }
+  let(:publisher_did) { 'did:plc:ewvi7nxzyoun6zhxrhs64oiz' }
+
   before do
-    BlueFactory.set :hostname, 'feeds.example.com'
-    BlueFactory.set :publisher_did, 'did:plc:ewvi7nxzyoun6zhxrhs64oiz'
+    BlueFactory.instance_variable_set('@feeds', {})
+    BlueFactory.interactions_handler = nil
+    BlueFactory::Server.class_variable_set(:@@config_checked, false)
+
+    BlueFactory.set :hostname, hostname
+    BlueFactory.set :publisher_did, publisher_did
   end
 
-  it "returns ok" do
-    get "/xrpc/app.bsky.feed.describeFeedGenerator"
+  def json_body
+    JSON.parse(last_response.body)
+  end
 
-    expect(last_response.status).to eq(200)
-    expect(last_response.headers["Content-Type"]).to include("application/json")
+  describe 'configuration verification' do
+    it 'raises ConfigurationError when hostname is nil' do
+      BlueFactory.set :hostname, nil
+      BlueFactory::Server.class_variable_set(:@@config_checked, false)
+
+      expect { get '/xrpc/app.bsky.feed.describeFeedGenerator' }
+        .to raise_error(BlueFactory::ConfigurationError, /hostname/)
+    end
+
+    it 'raises ConfigurationError when publisher_did is nil' do
+      BlueFactory.set :publisher_did, nil
+      BlueFactory::Server.class_variable_set(:@@config_checked, false)
+
+      expect { get '/xrpc/app.bsky.feed.describeFeedGenerator' }
+        .to raise_error(BlueFactory::ConfigurationError, /publisher_did/)
+    end
+  end
+
+  describe 'GET /xrpc/app.bsky.feed.getFeedSkeleton' do
+    let(:feed_key) { 'alpha' }
+    let(:feed_uri) { "at://#{publisher_did}/#{BlueFactory::FEED_GENERATOR_TYPE}/#{feed_key}" }
+    let(:valid_post_uri) { 'at://did:plc:abc123def456/app.bsky.feed.post/abc123' }
+
+    it 'returns a valid skeleton response for a one-argument get_posts' do
+      handler = mock('one_arg_handler')
+      handler.expects(:call).with do |args|
+        args[:feed] == feed_uri &&
+          args[:cursor] == 'next' &&
+          args[:limit] == BlueFactory::MAX_LIMIT
+      end.returns({ posts: [valid_post_uri], cursor: :cursor_token, req_id: :req_token })
+
+      feed = Class.new do
+        def initialize(handler)
+          @handler = handler
+        end
+
+        def get_posts(args)
+          @handler.call(args)
+        end
+      end.new(handler)
+
+      BlueFactory.add_feed(feed_key, feed)
+
+      get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: feed_uri, cursor: 'next', limit: 999
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.headers['Content-Type']).to include('application/json')
+      expect(json_body).to eq(
+        'feed' => [{ 'post' => valid_post_uri }],
+        'cursor' => 'cursor_token',
+        'reqId' => 'req_token'
+      )
+    end
+
+    it 'passes a RequestContext to a two-argument get_posts' do
+      handler = mock('two_arg_handler')
+      handler.expects(:call).with do |args, context|
+        args[:feed] == feed_uri && context.is_a?(BlueFactory::RequestContext)
+      end.returns({ posts: [valid_post_uri] })
+
+      feed = Class.new do
+        def initialize(handler)
+          @handler = handler
+        end
+
+        def get_posts(args, context)
+          @handler.call(args, context)
+        end
+      end.new(handler)
+
+      BlueFactory.add_feed(feed_key, feed)
+
+      get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: feed_uri
+
+      expect(last_response.status).to eq(200)
+      expect(json_body['feed']).to eq([{ 'post' => valid_post_uri }])
+    end
+
+    it 'raises InvalidFeedClassError when get_posts arity is unsupported' do
+      feed = Class.new do
+        def get_posts; end
+      end.new
+
+      BlueFactory.add_feed(feed_key, feed)
+
+      expect { get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: feed_uri }
+        .to raise_error(BlueFactory::InvalidFeedClassError, /arity 0/)
+    end
+
+    it 'returns InvalidRequest when feed is missing' do
+      get '/xrpc/app.bsky.feed.getFeedSkeleton'
+
+      expect(last_response.status).to eq(400)
+      expect(json_body).to include(
+        'error' => 'InvalidRequest',
+        'message' => 'Error: Params must have the property "feed"'
+      )
+    end
+
+    it 'returns InvalidRequest when feed is not a valid at-uri' do
+      get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: 'not-an-at-uri'
+
+      expect(last_response.status).to eq(400)
+      expect(json_body).to include(
+        'error' => 'InvalidRequest',
+        'message' => 'Error: feed must be a valid at-uri'
+      )
+    end
+
+    it 'returns UnsupportedAlgorithm when the feed is not registered' do
+      get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: feed_uri
+
+      expect(last_response.status).to eq(400)
+      expect(json_body).to include(
+        'error' => 'UnsupportedAlgorithm',
+        'message' => 'Unsupported algorithm'
+      )
+    end
+
+    it 'returns UnsupportedAlgorithm when the URI does not match the registered feed' do
+      feed = Class.new do
+        def get_posts(args); end
+      end.new
+
+      BlueFactory.add_feed(feed_key, feed)
+
+      mismatched_uri = "at://did:plc:someoneelse/#{BlueFactory::FEED_GENERATOR_TYPE}/#{feed_key}"
+      get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: mismatched_uri
+
+      expect(last_response.status).to eq(400)
+      expect(json_body).to include(
+        'error' => 'UnsupportedAlgorithm',
+        'message' => 'Unsupported algorithm'
+      )
+    end
+
+    it 'returns Unauthorized when the feed raises AuthorizationError' do
+      feed = Class.new do
+        def get_posts(_args, context)
+          context.user.raw_did
+          { posts: [] }
+        end
+      end.new
+
+      BlueFactory.add_feed(feed_key, feed)
+
+      header 'Authorization', 'Basic not-a-bearer-token'
+      get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: feed_uri
+
+      expect(last_response.status).to eq(401)
+      expect(json_body).to include(
+        'error' => 'AuthenticationRequired',
+        'message' => 'Unsupported authorization method'
+      )
+    end
+
+    it 'returns a generic InvalidResponse error in non-development environments' do
+      handler = mock('invalid_response_handler')
+      handler.stubs(:call).returns({ posts: 'not-an-array' })
+
+      feed = Class.new do
+        def initialize(handler)
+          @handler = handler
+        end
+
+        def get_posts(args)
+          @handler.call(args)
+        end
+      end.new(handler)
+      BlueFactory.add_feed(feed_key, feed)
+
+      get '/xrpc/app.bsky.feed.getFeedSkeleton', feed: feed_uri
+
+      expect(last_response.status).to eq(500)
+      expect(json_body).to include(
+        'error' => 'InvalidResponse',
+        'message' => 'Feed response was invalid'
+      )
+    end
+  end
+
+  describe 'GET /xrpc/app.bsky.feed.describeFeedGenerator' do
+    it 'returns the service did and configured feed uris' do
+      feed = Class.new do
+        def get_posts(args); end
+      end.new
+
+      BlueFactory.add_feed('alpha', feed)
+      BlueFactory.add_feed('beta', feed)
+
+      get '/xrpc/app.bsky.feed.describeFeedGenerator'
+
+      expect(last_response.status).to eq(200)
+      expect(json_body).to eq(
+        'did' => "did:web:#{hostname}",
+        'feeds' => [
+          { 'uri' => "at://#{publisher_did}/#{BlueFactory::FEED_GENERATOR_TYPE}/alpha" },
+          { 'uri' => "at://#{publisher_did}/#{BlueFactory::FEED_GENERATOR_TYPE}/beta" }
+        ]
+      )
+    end
+  end
+
+  describe 'GET /.well-known/did.json' do
+    it 'returns the expected DID document' do
+      get '/.well-known/did.json'
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.headers['Content-Type']).to include('application/json')
+      expect(json_body).to eq(
+        '@context' => ['https://www.w3.org/ns/did/v1'],
+        'id' => "did:web:#{hostname}",
+        'service' => [
+          {
+            'id' => '#bsky_fg',
+            'type' => 'BskyFeedGenerator',
+            'serviceEndpoint' => "https://#{hostname}"
+          }
+        ]
+      )
+    end
+  end
+
+  describe 'POST /xrpc/app.bsky.feed.sendInteractions' do
+    let(:interaction_event) { 'app.bsky.feed.defs#interactionSeen' }
+    let(:interaction_item) { 'at://did:plc:abc123def456/app.bsky.feed.post/abc123' }
+
+    it 'calls the configured interactions handler' do
+      received_interactions = nil
+      received_context = nil
+
+      BlueFactory.on_interactions do |interactions, context|
+        received_interactions = interactions
+        received_context = context
+      end
+
+      payload = {
+        interactions: [
+          {
+            event: interaction_event,
+            item: interaction_item,
+            feedContext: 'ctx',
+            reqId: 'req-1'
+          }
+        ]
+      }
+
+      post '/xrpc/app.bsky.feed.sendInteractions', JSON.generate(payload), 'CONTENT_TYPE' => 'application/json'
+
+      expect(last_response.status).to eq(200)
+      expect(received_context).to be_a(BlueFactory::RequestContext)
+      expect(received_interactions.map(&:type)).to eq([:seen])
+      expect(received_interactions.map(&:item)).to eq([interaction_item])
+      expect(received_interactions.map(&:context)).to eq(['ctx'])
+      expect(received_interactions.map(&:req_id)).to eq(['req-1'])
+    end
+
+    it 'returns MethodNotImplemented when no handler is configured' do
+      post '/xrpc/app.bsky.feed.sendInteractions', JSON.generate(interactions: []), 'CONTENT_TYPE' => 'application/json'
+
+      expect(last_response.status).to eq(501)
+      expect(json_body).to include(
+        'error' => 'MethodNotImplemented',
+        'message' => 'Method Not Implemented'
+      )
+    end
   end
 end


### PR DESCRIPTION
### Motivation
- Improve request-level test coverage for the server endpoints to exercise both success and error paths. 
- Ensure `getFeedSkeleton`, `describeFeedGenerator`, `/.well-known/did.json` and `sendInteractions` behaviors are verified, including configuration validation and feed handler edge cases.

### Description
- Replace the minimal existing spec with an expanded `spec/server_spec.rb` that resets shared `BlueFactory` state and provides a `json_body` helper for JSON assertions. 
- Add configuration verification specs that assert `ConfigurationError` is raised when `hostname` or `publisher_did` is `nil`. 
- Exercise `GET /xrpc/app.bsky.feed.getFeedSkeleton` across all code paths using `mocha` mocks for feed handlers to cover 1-arg and 2-arg `get_posts`, invalid arity, missing/invalid `feed` param, unsupported algorithm cases, authorization errors, and invalid feed responses. 
- Add assertions for `GET /xrpc/app.bsky.feed.describeFeedGenerator`, `GET /.well-known/did.json`, and `POST /xrpc/app.bsky.feed.sendInteractions` for both configured handler and no-handler (`501`) cases. 

### Testing
- Ran `bundle install` successfully to install test dependencies. 
- Ran the focused spec with `bundle exec rspec spec/server_spec.rb` which completed with all examples passing. 
- Ran the full test suite with `bundle exec rspec` which also completed with all examples passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69750429b78c833182e04de4e75e7034)